### PR TITLE
Trim L10N strings

### DIFF
--- a/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
+++ b/DTAConfig/OptionPanels/UpdaterOptionsPanel.cs
@@ -84,7 +84,7 @@ namespace DTAConfig.OptionPanels
                     "made to this installation. Use at your own risk!\n\n" +
                     "If you proceed, the options window will close and the\n" +
                     "client will proceed to checking for updates.\n\n" +
-                    "Do you really want to force update?\n").L10N("Client:DTAConfig:ForceUpdateConfirmText"), XNAMessageBoxButtons.YesNo);
+                    "Do you really want to force update?").L10N("Client:DTAConfig:ForceUpdateConfirmText") + "\n", XNAMessageBoxButtons.YesNo);
             msgBox.Show();
             msgBox.YesClickedAction = ForceUpdateMsgBox_YesClicked;
         }

--- a/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/CnCNet/CnCNetGameLoadingLobby.cs
@@ -611,7 +611,7 @@ namespace DTAClient.DXGUI.Multiplayer.CnCNet
             {
                 ShowTunnelSelectionWindow(("An error occured while contacting the CnCNet tunnel server.\nTry picking a different tunnel server:").L10N("Client:Main:ConnectTunnelError1"));
                 AddNotice(("An error occured while contacting the specified CnCNet " +
-                    "tunnel server. Please try using a different tunnel server ").L10N("Client:Main:ConnectTunnelError2"), Color.Yellow);
+                    "tunnel server. Please try using a different tunnel server").L10N("Client:Main:ConnectTunnelError2") + " ", Color.Yellow);
                 return;
             }
 

--- a/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
+++ b/DXMainClient/DXGUI/Multiplayer/GameLobby/CnCNetGameLobby.cs
@@ -636,7 +636,7 @@ namespace DTAClient.DXGUI.Multiplayer.GameLobby
                     ShowTunnelSelectionWindow(("An error occured while contacting " +
                         "the CnCNet tunnel server.\nTry picking a different tunnel server:").L10N("Client:Main:ConnectTunnelError1"));
                     AddNotice(("An error occured while contacting the specified CnCNet " +
-                        "tunnel server. Please try using a different tunnel server ").L10N("Client:Main:ConnectTunnelError2"), ERROR_MESSAGE_COLOR);
+                        "tunnel server. Please try using a different tunnel server").L10N("Client:Main:ConnectTunnelError2") + " ", ERROR_MESSAGE_COLOR);
                     return;
                 }
 

--- a/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
+++ b/DXMainClient/DXGUI/Multiplayer/PlayerExtraOptionsPanel.cs
@@ -251,9 +251,9 @@ namespace DTAClient.DXGUI.Multiplayer
                 ("Auto allying allows the host to assign starting locations to teams, not players.\n" +
                 "When players are assigned to spawn locations, they will be auto assigned to teams based on these mappings.\n" +
                 "This is best used with random teams and random starts. However, only random teams is required.\n" +
-                "Manually specified starts will take precedence.\n\n").L10N("Client:Main:AutoAllyingText1") +
+                "Manually specified starts will take precedence.").L10N("Client:Main:AutoAllyingText1") + "\n\n" +
                 $"{TeamStartMapping.NO_TEAM} : " + "Block this location from being assigned to a player.".L10N("Client:Main:AutoAllyingTextNoTeam") + "\n" +
-                $"{TeamStartMapping.RANDOM_TEAM} : "+"Allow a player here, but don't assign a team.".L10N("Client:Main:AutoAllyingTextRandomTeam")
+                $"{TeamStartMapping.RANDOM_TEAM} : " + "Allow a player here, but don't assign a team.".L10N("Client:Main:AutoAllyingTextRandomTeam")
             );
         }
 

--- a/TranslationNotifierGenerator/TranslationNotifierGenerator.cs
+++ b/TranslationNotifierGenerator/TranslationNotifierGenerator.cs
@@ -107,6 +107,11 @@ namespace TranslationNotifierGenerator
                         continue;
                     }
 
+                    if (valueText.Trim() != valueText)
+                    {
+                        Warn($"The value of key {keyName} should not have leading or trailing white spaces.", context, l10nSyntax);
+                    }
+
                     translations.Add(keyName, valueText);
                 }
             }


### PR DESCRIPTION
This removes leading and trailing spaces to avoid something like `Client:Main:Foo=Bar ` where there is a space after "Bar"