### PR TITLE
Add default Translation.Instance to prevent L10N crashes

### DIFF
--- a/ClientCore/I18N/Translation.cs
+++ b/ClientCore/I18N/Translation.cs
@@ -11,7 +11,7 @@ namespace ClientCore.I18N;
 
 public class Translation : ICloneable
 {
-    public static Translation Instance { get; set; }
+    public static Translation Instance { get; set; } = new Translation(ProgramConstants.HARDCODED_LOCALE_CODE);
 
     /// <summary>The translation metadata section name.</summary>
     public const string METADATA_SECTION = "General";

--- a/ClientCore/I18N/Translation.cs
+++ b/ClientCore/I18N/Translation.cs
@@ -16,8 +16,13 @@ public class Translation : ICloneable
     /// <summary>The translation metadata section name.</summary>
     public const string METADATA_SECTION = "General";
 
-    /// <summary>The culture that was set before the translation instance was created.</summary>
-    public static readonly CultureInfo InitialUICulture = CultureInfo.CurrentUICulture;
+    /// <summary>The culture that was set before the translation instance was created. Initialized at DXMainClient.PreStartup.Initialize().</summary>
+    private static CultureInfo _initialUICulture;
+    public static CultureInfo InitialUICulture
+    {
+        get { return _initialUICulture; }
+        set { _initialUICulture = _initialUICulture is null ? value : throw new InvalidOperationException(); }
+    }
 
     /// <summary>AKA name of the folder, used to look up <see cref="Culture"/> and select a language</summary>
     public string LocaleCode { get; private set; } = string.Empty;

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -115,16 +115,16 @@ namespace DTAClient
                         Logger.Log($"Loading theme-specific translation file at {translationThemeFile.FullName}");
                         translation.AppendValuesFromIniFile(translationThemeFile.FullName);
                     }
+
+                    Translation.Instance = translation;
                 }
                 else
                 {
                     Logger.Log($"Failed to load a translation file. " +
                         $"Neither {translationThemeFile.FullName} nor {translationFile.FullName} exist.");
-                    translation = new Translation(UserINISettings.Instance.Translation);
                 }
 
-                Translation.Instance = translation;
-                Logger.Log("Loaded translation: " + translation.Name);
+                Logger.Log("Loaded translation: " + Translation.Instance.Name);
             }
             catch (Exception ex)
             {

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -51,6 +51,7 @@ namespace DTAClient
         /// <param name="parameters">The client's startup parameters.</param>
         public static void Initialize(StartupParams parameters)
         {
+            Translation.InitialUICulture = CultureInfo.CurrentUICulture;
 #if WINFORMS
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
             Application.ThreadException += (sender, args) => HandleException(sender, args.Exception);

--- a/DXMainClient/PreStartup.cs
+++ b/DXMainClient/PreStartup.cs
@@ -52,6 +52,8 @@ namespace DTAClient
         public static void Initialize(StartupParams parameters)
         {
             Translation.InitialUICulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentUICulture = new CultureInfo(ProgramConstants.HARDCODED_LOCALE_CODE);
+
 #if WINFORMS
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);
             Application.ThreadException += (sender, args) => HandleException(sender, args.Exception);


### PR DESCRIPTION
```txt
System.NullReferenceException: 'Object reference not set to an instance of an object.'
```
at
```cs
public static string L10N(this string defaultValue, string key, bool notify = true)
        => string.IsNullOrEmpty(defaultValue)
            ? defaultValue
            : Translation.Instance.LookUp(key, defaultValue, notify);
```
      
This is called by `PreStartup.cs`
```cs
        static void HandleException(object sender, Exception ex) {
            ...
            string error = string.Format("{0} has crashed. Error message:".L10N("Client:Main:FatalErrorText1") + Environment.NewLine + Environment.NewLine +
                ex.Message + Environment.NewLine + Environment.NewLine + (crashLogCopied ?
                "A crash log has been saved to the following file:".L10N("Client:Main:FatalErrorText2") + " " + Environment.NewLine + Environment.NewLine +
                errorLogPath + Environment.NewLine + Environment.NewLine : "") +
                (crashLogCopied ? "If the issue is repeatable, contact the {1} staff at {2} and provide the crash log file.".L10N("Client:Main:FatalErrorText3") :
                "If the issue is repeatable, contact the {1} staff at {2}.".L10N("Client:Main:FatalErrorText4")),
                MainClientConstants.GAME_NAME_LONG,
                MainClientConstants.GAME_NAME_SHORT,
                MainClientConstants.SUPPORT_URL_SHORT);
```

and by `ClientConfiguration.cs`

```cs
        protected ClientConfiguration()
        {
            var baseResourceDirectory = SafePath.GetDirectory(ProgramConstants.GetBaseResourcePath());

            if (!baseResourceDirectory.Exists)
                throw new FileNotFoundException($"Couldn't find {CLIENT_DEFS} at {baseResourceDirectory} (directory doesn't exist). Please verify that you're running the client from the correct directory.");
```

The code in `HandleException` can be triggered both before and after loading a translation. So `Translation.Instance` must be initialized to ensure error prompts are displayed.
